### PR TITLE
Add describe_group/2,3 API in KafkaEx

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -14,9 +14,6 @@ workflows:
           context: Hex
       - hold-for-dev-publish:
           type: approval
-          requires:
-            - elixir-orb/test
-            - elixir-orb/static-check
           filters:
             branches:
               ignore:
@@ -27,9 +24,6 @@ workflows:
             - hold-for-dev-publish
       - elixir-orb/deploy:
           context: Hex
-          requires:
-            - elixir-orb/test
-            - elixir-orb/static-check
           filters:
             branches:
               only:

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -200,6 +200,19 @@ defmodule KafkaEx do
   end
 
   @doc """
+  Sends a request to describe a group identified by its name.
+  """
+  @spec describe_group(binary, Keyword.t()) :: term
+  def describe_group(consumer_group_name, opts \\ []) do
+    worker_name = Keyword.get(opts, :worker_name, Config.default_worker())
+    describe_group(worker_name, consumer_group_name, opts)
+  end
+
+  def describe_group(worker_name, consumer_group_name, opts) do
+    Server.call(worker_name, {:describe_group, consumer_group_name}, opts)
+  end
+
+  @doc """
   Get the offset of the latest message written to Kafka
 
   ## Example

--- a/lib/kafka_ex.ex
+++ b/lib/kafka_ex.ex
@@ -310,11 +310,12 @@ defmodule KafkaEx do
     api_version = Keyword.get(opts, :api_version, 0)
     # same for offset_commit_api_version
     offset_commit_api_version = Keyword.get(opts, :offset_commit_api_version, 0)
+
     # By default, it makes sense to synchronize the API version of the offset_commit and the offset_fetch
     # operations, otherwise we might commit the offsets in zookeeper and read them from Kafka, meaning
     # that the value would be incorrect.
-    offset_fetch_api_version = Keyword.get(opts, :offset_fetch_api_version, offset_commit_api_version)
-
+    offset_fetch_api_version =
+      Keyword.get(opts, :offset_fetch_api_version, offset_commit_api_version)
 
     retrieved_offset =
       current_offset(

--- a/lib/kafka_ex/gen_consumer.ex
+++ b/lib/kafka_ex/gen_consumer.ex
@@ -810,9 +810,7 @@ defmodule KafkaEx.GenConsumer do
           KafkaEx.latest_offset(topic, partition, worker_name)
 
         _ ->
-          raise "Offset out of range while consuming topic #{topic}, partition #{
-                  partition
-                }."
+          raise "Offset out of range while consuming topic #{topic}, partition #{partition}."
       end
 
     %State{

--- a/lib/kafka_ex/network_client.ex
+++ b/lib/kafka_ex/network_client.ex
@@ -25,9 +25,7 @@ defmodule KafkaEx.NetworkClient do
       err ->
         Logger.log(
           :error,
-          "Could not connect to broker #{inspect(host)}:#{inspect(port)} because of error #{
-            inspect(err)
-          }"
+          "Could not connect to broker #{inspect(host)}:#{inspect(port)} because of error #{inspect(err)}"
         )
 
         nil
@@ -50,9 +48,7 @@ defmodule KafkaEx.NetworkClient do
       {_, reason} ->
         Logger.log(
           :error,
-          "Asynchronously sending data to broker #{inspect(broker.host)}:#{
-            inspect(broker.port)
-          } failed with #{inspect(reason)}"
+          "Asynchronously sending data to broker #{inspect(broker.host)}:#{inspect(broker.port)} failed with #{inspect(reason)}"
         )
 
         reason
@@ -77,9 +73,7 @@ defmodule KafkaEx.NetworkClient do
             {:error, reason} ->
               Logger.log(
                 :error,
-                "Receiving data from broker #{inspect(broker.host)}:#{
-                  inspect(broker.port)
-                } failed with #{inspect(reason)}"
+                "Receiving data from broker #{inspect(broker.host)}:#{inspect(broker.port)} failed with #{inspect(reason)}"
               )
 
               Socket.close(socket)
@@ -90,9 +84,7 @@ defmodule KafkaEx.NetworkClient do
         {_, reason} ->
           Logger.log(
             :error,
-            "Sending data to broker #{inspect(broker.host)}:#{
-              inspect(broker.port)
-            } failed with #{inspect(reason)}"
+            "Sending data to broker #{inspect(broker.host)}:#{inspect(broker.port)} failed with #{inspect(reason)}"
           )
 
           Socket.close(socket)

--- a/lib/kafka_ex/new/client.ex
+++ b/lib/kafka_ex/new/client.ex
@@ -166,8 +166,7 @@ defmodule KafkaEx.New.Client do
   end
 
   def handle_call({:describe_group, consumer_group_name}, _from, state) do
-    {response, updated_state} =
-      describe_group(state, consumer_group_name)
+    {response, updated_state} = describe_group(state, consumer_group_name)
 
     {:reply, {:ok, response}, updated_state}
   end

--- a/lib/kafka_ex/protocol/fetch.ex
+++ b/lib/kafka_ex/protocol/fetch.ex
@@ -67,7 +67,7 @@ defmodule KafkaEx.Protocol.Fetch do
             offset: integer,
             key: binary,
             value: binary,
-            headers: [{key::binary, value::binary}],
+            headers: [{key :: binary, value :: binary}],
             topic: binary,
             partition: integer,
             # timestamp supported for `kafka_version: "kayrock"` ONLY
@@ -164,9 +164,7 @@ defmodule KafkaEx.Protocol.Fetch do
        )
        when byte_size(partial_message_data) < msg_size do
     raise RuntimeError,
-          "Insufficient data fetched at offset #{offset}. Message size is #{
-            msg_size
-          } but only received #{byte_size(partial_message_data)} bytes. Try increasing max_bytes."
+          "Insufficient data fetched at offset #{offset}. Message size is #{msg_size} but only received #{byte_size(partial_message_data)} bytes. Try increasing max_bytes."
   end
 
   # handles the single message case and the batch (compression) case

--- a/lib/kafka_ex/protocol/produce.ex
+++ b/lib/kafka_ex/protocol/produce.ex
@@ -59,7 +59,7 @@ defmodule KafkaEx.Protocol.Produce do
     @type t :: %Message{
             key: binary,
             value: binary,
-            headers: [{key::binary, value::binary}],
+            headers: [{key :: binary, value :: binary}],
             timestamp: integer
           }
   end

--- a/lib/kafka_ex/server.ex
+++ b/lib/kafka_ex/server.ex
@@ -373,9 +373,7 @@ defmodule KafkaEx.Server do
       def terminate(reason, state) do
         Logger.log(
           :debug,
-          "Shutting down worker #{inspect(state.worker_name)}, reason: #{
-            inspect(reason)
-          }"
+          "Shutting down worker #{inspect(state.worker_name)}, reason: #{inspect(reason)}"
         )
 
         if state.event_pid do
@@ -471,9 +469,7 @@ defmodule KafkaEx.Server do
             nil ->
               Logger.log(
                 :error,
-                "kafka_server_produce_send_request: leader for topic #{
-                  produce_request.topic
-                }/#{produce_request.partition} is not available"
+                "kafka_server_produce_send_request: leader for topic #{produce_request.topic}/#{produce_request.partition} is not available"
               )
 
               :leader_not_available
@@ -678,9 +674,7 @@ defmodule KafkaEx.Server do
           ) do
         Logger.log(
           :error,
-          "Metadata request for topic #{inspect(topic)} failed with error_code #{
-            inspect(error_code)
-          }"
+          "Metadata request for topic #{inspect(topic)} failed with error_code #{inspect(error_code)}"
         )
 
         {correlation_id, %Metadata.Response{}}
@@ -731,9 +725,7 @@ defmodule KafkaEx.Server do
           end
         else
           message =
-            "Unable to fetch metadata from any brokers. Timeout is #{
-              sync_timeout
-            }."
+            "Unable to fetch metadata from any brokers. Timeout is #{sync_timeout}."
 
           Logger.log(:error, message)
           raise message
@@ -862,9 +854,7 @@ defmodule KafkaEx.Server do
         case broker do
           nil ->
             Logger.error(fn ->
-              "network_request: leader for topic #{request.topic}/#{
-                request.partition
-              } is not available"
+              "network_request: leader for topic #{request.topic}/#{request.partition} is not available"
             end)
 
             {{:error, :topic_not_found}, updated_state}
@@ -891,15 +881,11 @@ defmodule KafkaEx.Server do
                   rescue
                     _ ->
                       Logger.error(
-                        "Failed to parse a response from the server: #{
-                          inspect(response)
-                        }"
+                        "Failed to parse a response from the server: #{inspect(response)}"
                       )
 
                       Kernel.reraise(
-                        "Parse error during #{inspect(module)}.parse_response. Couldn't parse: #{
-                          inspect(response)
-                        }",
+                        "Parse error during #{inspect(module)}.parse_response. Couldn't parse: #{inspect(response)}",
                         System.stacktrace()
                       )
                   end
@@ -932,9 +918,7 @@ defmodule KafkaEx.Server do
             Enum.each(brokers_to_remove, fn broker ->
               Logger.log(
                 :debug,
-                "Closing connection to broker #{broker.node_id}: #{
-                  inspect(broker.host)
-                } on port #{inspect(broker.port)}"
+                "Closing connection to broker #{broker.node_id}: #{inspect(broker.host)} on port #{inspect(broker.port)}"
               )
 
               NetworkClient.close_socket(broker.socket)
@@ -956,9 +940,7 @@ defmodule KafkaEx.Server do
           nil ->
             Logger.log(
               :debug,
-              "Establishing connection to broker #{metadata_broker.node_id}: #{
-                inspect(metadata_broker.host)
-              } on port #{inspect(metadata_broker.port)}"
+              "Establishing connection to broker #{metadata_broker.node_id}: #{inspect(metadata_broker.host)} on port #{inspect(metadata_broker.port)}"
             )
 
             add_new_brokers(

--- a/lib/kafka_ex/server_0_p_8_p_2.ex
+++ b/lib/kafka_ex/server_0_p_8_p_2.ex
@@ -226,9 +226,7 @@ defmodule KafkaEx.Server0P8P2 do
       ) do
     Logger.log(
       :error,
-      "Fetching consumer_group #{consumer_group} metadata failed with error_code #{
-        inspect(error_code)
-      }"
+      "Fetching consumer_group #{consumer_group} metadata failed with error_code #{inspect(error_code)}"
     )
 
     {%ConsumerMetadataResponse{error_code: error_code}, state}

--- a/mix.exs
+++ b/mix.exs
@@ -2,8 +2,8 @@ defmodule KafkaEx.Mixfile do
   @moduledoc false
   use Mix.Project
 
-  @source_url "https://github.com/kafkaex/kafka_ex"
-  @version "0.12.1"
+  @source_url "https://github.com/surgeventures/kafka_ex"
+  @version "0.1.0"
 
   def project do
     [
@@ -49,8 +49,7 @@ defmodule KafkaEx.Mixfile do
       {:credo, "~> 1.1", only: [:dev, :test], runtime: false},
       {:dialyxir, "~> 1.0.0-rc.3", only: :dev, runtime: false},
       {:excoveralls, "~> 0.7", only: :test, runtime: false},
-      {:snappy,
-       git: "https://github.com/fdmanana/snappy-erlang-nif", only: [:dev, :test]},
+      {:snappy, git: "https://github.com/fdmanana/snappy-erlang-nif", only: [:dev, :test]},
       {:snappyer, "~> 1.2", only: [:dev, :test]}
     ]
 
@@ -68,12 +67,13 @@ defmodule KafkaEx.Mixfile do
   end
 
   defp package do
-    [
+    %{
       name: :kafka_ex_fresha,
       maintainers: ["Abejide Ayodele", "Dan Swain", "Jack Lund", "Joshua Scott"],
       files: ["lib", "config/config.exs", "mix.exs", "README.md"],
       licenses: ["MIT"],
-      links: %{"GitHub" => @source_url}
-    ]
+      links: %{"GitHub" => @source_url},
+      organization: "fresha"
+    }
   end
 end

--- a/test/integration/consumer_group_test.exs
+++ b/test/integration/consumer_group_test.exs
@@ -11,19 +11,6 @@ defmodule KafkaEx.ConsumerGroup.Test do
              KafkaEx.consumer_group()
   end
 
-  test "create_worker returns an error when an invalid consumer group is provided" do
-    assert {:error, :invalid_consumer_group} ==
-             KafkaEx.create_worker(:francine, consumer_group: 0)
-  end
-
-  test "create_worker allows us to disable the consumer group" do
-    {:ok, pid} =
-      KafkaEx.create_worker(:barney, consumer_group: :no_consumer_group)
-
-    consumer_group = :sys.get_state(pid).consumer_group
-    assert consumer_group == :no_consumer_group
-  end
-
   describe "custom ssl options" do
     setup do
       # reset application env after each test
@@ -87,632 +74,660 @@ defmodule KafkaEx.ConsumerGroup.Test do
     end
   end
 
-  test "create_worker allows us to provide a consumer group" do
-    {:ok, pid} =
-      KafkaEx.create_worker(:bah, consumer_group: "my_consumer_group")
+  describe "create_worker/2" do
+    test "create_worker returns an error when an invalid consumer group is provided" do
+      assert {:error, :invalid_consumer_group} ==
+               KafkaEx.create_worker(:francine, consumer_group: 0)
+    end
 
-    consumer_group = :sys.get_state(pid).consumer_group
+    test "create_worker allows us to disable the consumer group" do
+      {:ok, pid} =
+        KafkaEx.create_worker(:barney, consumer_group: :no_consumer_group)
 
-    assert consumer_group == "my_consumer_group"
+      consumer_group = :sys.get_state(pid).consumer_group
+      assert consumer_group == :no_consumer_group
+    end
+
+    test "create_worker allows us to provide a consumer group" do
+      {:ok, pid} =
+        KafkaEx.create_worker(:bah, consumer_group: "my_consumer_group")
+
+      consumer_group = :sys.get_state(pid).consumer_group
+
+      assert consumer_group == "my_consumer_group"
+    end
+
+    test "create_worker allows custom consumer_group_update_interval" do
+      {:ok, pid} =
+        KafkaEx.create_worker(
+          :consumer_group_update_interval_custom,
+          uris: uris(),
+          consumer_group_update_interval: 10
+        )
+
+      consumer_group_update_interval =
+        :sys.get_state(pid).consumer_group_update_interval
+
+      assert consumer_group_update_interval == 10
+    end
+
+    test "create_worker provides a default consumer_group_update_interval of '30000'" do
+      {:ok, pid} = KafkaEx.create_worker(:de, uris: uris())
+
+      consumer_group_update_interval =
+        :sys.get_state(pid).consumer_group_update_interval
+
+      assert consumer_group_update_interval == 30000
+    end
+
+    test "create_worker provides a default consumer_group of 'kafka_ex'" do
+      {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris())
+      consumer_group = :sys.get_state(pid).consumer_group
+
+      assert consumer_group == "kafka_ex"
+    end
+
+    test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
+      {:ok, pid} =
+        KafkaEx.create_worker(:joe, uris: uris(), consumer_group: "foo")
+
+      consumer_group = :sys.get_state(pid).consumer_group
+
+      assert consumer_group == "foo"
+    end
+
+    test "asking the worker for the name of its consumer group" do
+      consumer_group = "this_is_my_consumer_group"
+      worker_name = :consumer_group_reader_test
+
+      {:ok, _pid} =
+        KafkaEx.create_worker(
+          worker_name,
+          consumer_group: consumer_group
+        )
+
+      assert consumer_group == KafkaEx.consumer_group(worker_name)
+    end
+
+    test "worker updates metadata after specified interval" do
+      {:ok, pid} =
+        KafkaEx.create_worker(
+          :update_consumer_metadata,
+          uris: uris(),
+          consumer_group: "kafka_ex",
+          consumer_group_update_interval: 100
+        )
+
+      consumer_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{}
+
+      :sys.replace_state(pid, fn state ->
+        %{state | :consumer_metadata => consumer_metadata}
+      end)
+
+      :timer.sleep(105)
+      new_consumer_metadata = :sys.get_state(pid).consumer_metadata
+
+      refute new_consumer_metadata == consumer_metadata
+    end
+
+    test "worker does not update metadata when consumer_group is disabled" do
+      {:ok, pid} =
+        KafkaEx.create_worker(
+          :no_consumer_metadata_update,
+          uris: uris(),
+          consumer_group: :no_consumer_group,
+          consumer_group_update_interval: 100
+        )
+
+      consumer_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{}
+
+      :sys.replace_state(pid, fn state ->
+        %{state | :consumer_metadata => consumer_metadata}
+      end)
+
+      :timer.sleep(105)
+      new_consumer_metadata = :sys.get_state(pid).consumer_metadata
+
+      assert new_consumer_metadata == consumer_metadata
+    end
   end
 
-  test "create_worker allows custom consumer_group_update_interval" do
-    {:ok, pid} =
+  describe "consumer_group_metadata/2" do
+    test "consumer_group_metadata works" do
+      random_string = generate_random_string()
+
+      KafkaEx.produce(%Proto.Produce.Request{
+        topic: "food",
+        partition: 0,
+        required_acks: 1,
+        messages: [%Proto.Produce.Message{value: "hey"}]
+      })
+
+      KafkaEx.fetch("food", 0, offset: 0)
+
       KafkaEx.create_worker(
-        :consumer_group_update_interval_custom,
-        uris: uris(),
-        consumer_group_update_interval: 10
+        :consumer_group_metadata_worker,
+        consumer_group: random_string,
+        uris: Application.get_env(:kafka_ex, :brokers)
       )
 
-    consumer_group_update_interval =
-      :sys.get_state(pid).consumer_group_update_interval
+      pid = Process.whereis(:consumer_group_metadata_worker)
 
-    assert consumer_group_update_interval == 10
+      metadata =
+        KafkaEx.consumer_group_metadata(
+          :consumer_group_metadata_worker,
+          random_string
+        )
+
+      consumer_group_metadata = :sys.get_state(pid).consumer_metadata
+
+      assert metadata != %Proto.ConsumerMetadata.Response{}
+      assert metadata.coordinator_host != nil
+      assert metadata.error_code == :no_error
+      assert metadata == consumer_group_metadata
+    end
   end
 
-  test "create_worker provides a default consumer_group_update_interval of '30000'" do
-    {:ok, pid} = KafkaEx.create_worker(:de, uris: uris())
+  describe "fetch/3" do
+    test "fetch auto_commits offset by default" do
+      worker_name = :fetch_test_worker
+      topic = "kafka_ex_consumer_group_test"
+      consumer_group = "auto_commit_consumer_group"
 
-    consumer_group_update_interval =
-      :sys.get_state(pid).consumer_group_update_interval
-
-    assert consumer_group_update_interval == 30000
-  end
-
-  test "create_worker provides a default consumer_group of 'kafka_ex'" do
-    {:ok, pid} = KafkaEx.create_worker(:baz, uris: uris())
-    consumer_group = :sys.get_state(pid).consumer_group
-
-    assert consumer_group == "kafka_ex"
-  end
-
-  test "create_worker takes a consumer_group option and sets that as the consumer_group of the worker" do
-    {:ok, pid} =
-      KafkaEx.create_worker(:joe, uris: uris(), consumer_group: "foo")
-
-    consumer_group = :sys.get_state(pid).consumer_group
-
-    assert consumer_group == "foo"
-  end
-
-  test "asking the worker for the name of its consumer group" do
-    consumer_group = "this_is_my_consumer_group"
-    worker_name = :consumer_group_reader_test
-
-    {:ok, _pid} =
       KafkaEx.create_worker(
         worker_name,
+        uris: Application.get_env(:kafka_ex, :brokers),
         consumer_group: consumer_group
       )
 
-    assert consumer_group == KafkaEx.consumer_group(worker_name)
-  end
+      offset_before = TestHelper.latest_offset_number(topic, 0, worker_name)
 
-  test "consumer_group_metadata works" do
-    random_string = generate_random_string()
+      Enum.each(1..10, fn _ ->
+        msg = %Proto.Produce.Message{value: "hey #{inspect(:os.timestamp())}"}
 
-    KafkaEx.produce(%Proto.Produce.Request{
-      topic: "food",
-      partition: 0,
-      required_acks: 1,
-      messages: [%Proto.Produce.Message{value: "hey"}]
-    })
+        KafkaEx.produce(
+          %Proto.Produce.Request{
+            topic: topic,
+            partition: 0,
+            required_acks: 1,
+            messages: [msg]
+          },
+          worker_name: worker_name
+        )
+      end)
 
-    KafkaEx.fetch("food", 0, offset: 0)
+      offset_after = TestHelper.latest_offset_number(topic, 0, worker_name)
+      assert offset_after == offset_before + 10
 
-    KafkaEx.create_worker(
-      :consumer_group_metadata_worker,
-      consumer_group: random_string,
-      uris: Application.get_env(:kafka_ex, :brokers)
-    )
+      [logs] =
+        KafkaEx.fetch(
+          topic,
+          0,
+          offset: offset_before,
+          worker_name: worker_name
+        )
 
-    pid = Process.whereis(:consumer_group_metadata_worker)
+      [partition] = logs.partitions
+      message_set = partition.message_set
+      assert 10 == length(message_set)
 
-    metadata =
-      KafkaEx.consumer_group_metadata(
-        :consumer_group_metadata_worker,
-        random_string
-      )
+      last_message = List.last(message_set)
+      offset_of_last_message = last_message.offset
 
-    consumer_group_metadata = :sys.get_state(pid).consumer_metadata
-
-    assert metadata != %Proto.ConsumerMetadata.Response{}
-    assert metadata.coordinator_host != nil
-    assert metadata.error_code == :no_error
-    assert metadata == consumer_group_metadata
-  end
-
-  # update_consumer_metadata
-  test "worker updates metadata after specified interval" do
-    {:ok, pid} =
-      KafkaEx.create_worker(
-        :update_consumer_metadata,
-        uris: uris(),
-        consumer_group: "kafka_ex",
-        consumer_group_update_interval: 100
-      )
-
-    consumer_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{}
-
-    :sys.replace_state(pid, fn state ->
-      %{state | :consumer_metadata => consumer_metadata}
-    end)
-
-    :timer.sleep(105)
-    new_consumer_metadata = :sys.get_state(pid).consumer_metadata
-
-    refute new_consumer_metadata == consumer_metadata
-  end
-
-  test "worker does not update metadata when consumer_group is disabled" do
-    {:ok, pid} =
-      KafkaEx.create_worker(
-        :no_consumer_metadata_update,
-        uris: uris(),
-        consumer_group: :no_consumer_group,
-        consumer_group_update_interval: 100
-      )
-
-    consumer_metadata = %KafkaEx.Protocol.ConsumerMetadata.Response{}
-
-    :sys.replace_state(pid, fn state ->
-      %{state | :consumer_metadata => consumer_metadata}
-    end)
-
-    :timer.sleep(105)
-    new_consumer_metadata = :sys.get_state(pid).consumer_metadata
-
-    assert new_consumer_metadata == consumer_metadata
-  end
-
-  # fetch
-  test "fetch auto_commits offset by default" do
-    worker_name = :fetch_test_worker
-    topic = "kafka_ex_consumer_group_test"
-    consumer_group = "auto_commit_consumer_group"
-
-    KafkaEx.create_worker(
-      worker_name,
-      uris: Application.get_env(:kafka_ex, :brokers),
-      consumer_group: consumer_group
-    )
-
-    offset_before = TestHelper.latest_offset_number(topic, 0, worker_name)
-
-    Enum.each(1..10, fn _ ->
-      msg = %Proto.Produce.Message{value: "hey #{inspect(:os.timestamp())}"}
-
-      KafkaEx.produce(
-        %Proto.Produce.Request{
-          topic: topic,
-          partition: 0,
-          required_acks: 1,
-          messages: [msg]
-        },
-        worker_name: worker_name
-      )
-    end)
-
-    offset_after = TestHelper.latest_offset_number(topic, 0, worker_name)
-    assert offset_after == offset_before + 10
-
-    [logs] =
-      KafkaEx.fetch(
-        topic,
-        0,
-        offset: offset_before,
-        worker_name: worker_name
-      )
-
-    [partition] = logs.partitions
-    message_set = partition.message_set
-    assert 10 == length(message_set)
-
-    last_message = List.last(message_set)
-    offset_of_last_message = last_message.offset
-
-    offset_request = %Proto.OffsetFetch.Request{
-      topic: topic,
-      partition: 0,
-      consumer_group: consumer_group
-    }
-
-    [offset_fetch_response] = KafkaEx.offset_fetch(worker_name, offset_request)
-    [partition] = offset_fetch_response.partitions
-    error_code = partition.error_code
-    offset_fetch_response_offset = partition.offset
-
-    assert error_code == :no_error
-    assert offset_of_last_message == offset_fetch_response_offset
-  end
-
-  test "fetch starts consuming from last committed offset" do
-    random_string = generate_random_string()
-    KafkaEx.create_worker(:fetch_test_committed_worker)
-
-    Enum.each(1..10, fn _ ->
-      KafkaEx.produce(%Proto.Produce.Request{
-        topic: random_string,
-        partition: 0,
-        required_acks: 1,
-        messages: [%Proto.Produce.Message{value: "hey"}]
-      })
-    end)
-
-    KafkaEx.offset_commit(
-      :fetch_test_committed_worker,
-      %Proto.OffsetCommit.Request{topic: random_string, offset: 3, partition: 0}
-    )
-
-    logs =
-      KafkaEx.fetch(random_string, 0, worker: :fetch_test_committed_worker)
-      |> hd
-      |> Map.get(:partitions)
-      |> hd
-      |> Map.get(:message_set)
-
-    first_message = logs |> hd
-
-    assert first_message.offset == 4
-    assert length(logs) == 6
-  end
-
-  test "fetch does not commit offset with auto_commit is set to false" do
-    topic = generate_random_string()
-    worker_name = :fetch_no_auto_commit_worker
-    KafkaEx.create_worker(worker_name)
-
-    Enum.each(1..10, fn _ ->
-      KafkaEx.produce(
-        %Proto.Produce.Request{
-          topic: topic,
-          partition: 0,
-          required_acks: 1,
-          messages: [%Proto.Produce.Message{value: "hey"}]
-        },
-        worker_name: worker_name
-      )
-    end)
-
-    offset =
-      KafkaEx.fetch(
-        topic,
-        0,
-        offset: 0,
-        worker: worker_name,
-        auto_commit: false
-      )
-      |> hd
-      |> Map.get(:partitions)
-      |> hd
-      |> Map.get(:message_set)
-      |> Enum.reverse()
-      |> hd
-      |> Map.get(:offset)
-
-    offset_fetch_response =
-      KafkaEx.offset_fetch(worker_name, %Proto.OffsetFetch.Request{
+      offset_request = %Proto.OffsetFetch.Request{
         topic: topic,
-        partition: 0
-      })
-      |> hd
-
-    offset_fetch_response_offset =
-      offset_fetch_response.partitions |> hd |> Map.get(:offset)
-
-    refute offset == offset_fetch_response_offset
-  end
-
-  # offset_fetch
-  test "offset_fetch does not override consumer_group" do
-    topic = generate_random_string()
-    worker_name = :offset_fetch_consumer_group
-    consumer_group = "bar#{topic}"
-
-    KafkaEx.create_worker(
-      worker_name,
-      consumer_group: consumer_group,
-      uris: Application.get_env(:kafka_ex, :brokers)
-    )
-
-    Enum.each(1..10, fn _ ->
-      KafkaEx.produce(
-        %Proto.Produce.Request{
-          topic: topic,
-          required_acks: 1,
-          partition: 0,
-          messages: [%Proto.Produce.Message{value: "hey"}]
-        },
-        worker_name: worker_name
-      )
-    end)
-
-    KafkaEx.offset_fetch(worker_name, %KafkaEx.Protocol.OffsetFetch.Request{
-      topic: topic,
-      partition: 0
-    })
-
-    assert :sys.get_state(:offset_fetch_consumer_group).consumer_group ==
-             consumer_group
-  end
-
-  # offset_commit
-  test "offset_commit commits an offset and offset_fetch retrieves the committed offset" do
-    random_string = generate_random_string()
-
-    Enum.each(1..10, fn _ ->
-      KafkaEx.produce(%Proto.Produce.Request{
-        topic: random_string,
         partition: 0,
-        required_acks: 1,
-        messages: [%Proto.Produce.Message{value: "hey"}]
-      })
-    end)
+        consumer_group: consumer_group
+      }
 
-    assert KafkaEx.offset_commit(
-             Config.default_worker(),
-             %Proto.OffsetCommit.Request{
-               topic: random_string,
-               offset: 9,
-               partition: 0
-             }
-           ) ==
-             [
-               %Proto.OffsetCommit.Response{
-                 partitions: [0],
-                 topic: random_string
-               }
-             ]
+      [offset_fetch_response] =
+        KafkaEx.offset_fetch(worker_name, offset_request)
 
-    assert KafkaEx.offset_fetch(
-             Config.default_worker(),
-             %Proto.OffsetFetch.Request{topic: random_string, partition: 0}
-           ) ==
-             [
-               %Proto.OffsetFetch.Response{
-                 partitions: [
-                   %{
-                     metadata: "",
-                     error_code: :no_error,
-                     offset: 9,
-                     partition: 0
-                   }
-                 ],
-                 topic: random_string
-               }
-             ]
-  end
+      [partition] = offset_fetch_response.partitions
+      error_code = partition.error_code
+      offset_fetch_response_offset = partition.offset
 
-  # stream
-  test "stream auto_commits offset by default" do
-    random_string = generate_random_string()
+      assert error_code == :no_error
+      assert offset_of_last_message == offset_fetch_response_offset
+    end
 
-    KafkaEx.create_worker(
-      :stream_auto_commit,
-      uris: uris(),
-      consumer_group: "kafka_ex"
-    )
+    test "fetch starts consuming from last committed offset" do
+      random_string = generate_random_string()
+      KafkaEx.create_worker(:fetch_test_committed_worker)
 
-    KafkaEx.produce(%Proto.Produce.Request{
-      topic: random_string,
-      partition: 0,
-      required_acks: 1,
-      messages: [
-        %Proto.Produce.Message{value: "hey"},
-        %Proto.Produce.Message{value: "hi"}
-      ]
-    })
-
-    stream =
-      KafkaEx.stream(
-        random_string,
-        0,
-        worker_name: :stream_auto_commit,
-        offset: 0
-      )
-
-    log = TestHelper.wait_for_any(fn -> Enum.take(stream, 2) end)
-
-    refute Enum.empty?(log)
-
-    [offset_fetch_response | _] =
-      KafkaEx.offset_fetch(:stream_auto_commit, %Proto.OffsetFetch.Request{
-        topic: random_string,
-        partition: 0
-      })
-
-    error_code = offset_fetch_response.partitions |> hd |> Map.get(:error_code)
-    offset = offset_fetch_response.partitions |> hd |> Map.get(:offset)
-
-    assert error_code == :no_error
-    refute offset == 0
-  end
-
-  test "stream starts consuming from the next offset" do
-    random_string = generate_random_string()
-    consumer_group = "kafka_ex"
-    worker_name = :stream_last_committed_offset
-
-    KafkaEx.create_worker(
-      worker_name,
-      uris: uris(),
-      consumer_group: consumer_group
-    )
-
-    Enum.each(1..10, fn _ ->
-      KafkaEx.produce(
-        %Proto.Produce.Request{
+      Enum.each(1..10, fn _ ->
+        KafkaEx.produce(%Proto.Produce.Request{
           topic: random_string,
           partition: 0,
           required_acks: 1,
           messages: [%Proto.Produce.Message{value: "hey"}]
-        },
-        worker_name: worker_name
-      )
-    end)
-
-    KafkaEx.offset_commit(worker_name, %Proto.OffsetCommit.Request{
-      topic: random_string,
-      partition: 0,
-      offset: 3
-    })
-
-    # make sure the offset commit is actually committed before we
-    # start streaming again
-    :ok =
-      TestHelper.wait_for(fn ->
-        3 ==
-          TestHelper.latest_consumer_offset_number(
-            random_string,
-            0,
-            consumer_group,
-            worker_name
-          )
+        })
       end)
 
-    stream = KafkaEx.stream(random_string, 0, worker_name: worker_name)
-    log = TestHelper.wait_for_any(fn -> Enum.take(stream, 2) end)
+      KafkaEx.offset_commit(
+        :fetch_test_committed_worker,
+        %Proto.OffsetCommit.Request{
+          topic: random_string,
+          offset: 3,
+          partition: 0
+        }
+      )
 
-    refute Enum.empty?(log)
-    first_message = log |> hd
-    assert first_message.offset == 4
+      logs =
+        KafkaEx.fetch(random_string, 0, worker: :fetch_test_committed_worker)
+        |> hd
+        |> Map.get(:partitions)
+        |> hd
+        |> Map.get(:message_set)
+
+      first_message = logs |> hd
+
+      assert first_message.offset == 4
+      assert length(logs) == 6
+    end
+
+    test "fetch does not commit offset with auto_commit is set to false" do
+      topic = generate_random_string()
+      worker_name = :fetch_no_auto_commit_worker
+      KafkaEx.create_worker(worker_name)
+
+      Enum.each(1..10, fn _ ->
+        KafkaEx.produce(
+          %Proto.Produce.Request{
+            topic: topic,
+            partition: 0,
+            required_acks: 1,
+            messages: [%Proto.Produce.Message{value: "hey"}]
+          },
+          worker_name: worker_name
+        )
+      end)
+
+      offset =
+        KafkaEx.fetch(
+          topic,
+          0,
+          offset: 0,
+          worker: worker_name,
+          auto_commit: false
+        )
+        |> hd
+        |> Map.get(:partitions)
+        |> hd
+        |> Map.get(:message_set)
+        |> Enum.reverse()
+        |> hd
+        |> Map.get(:offset)
+
+      offset_fetch_response =
+        KafkaEx.offset_fetch(worker_name, %Proto.OffsetFetch.Request{
+          topic: topic,
+          partition: 0
+        })
+        |> hd
+
+      offset_fetch_response_offset =
+        offset_fetch_response.partitions |> hd |> Map.get(:offset)
+
+      refute offset == offset_fetch_response_offset
+    end
   end
 
-  test "stream auto_commit deals with small batches correctly" do
-    topic_name = generate_random_string()
-    consumer_group = "stream_test"
+  describe "offset_fetch/2" do
+    test "offset_fetch does not override consumer_group" do
+      topic = generate_random_string()
+      worker_name = :offset_fetch_consumer_group
+      consumer_group = "bar#{topic}"
 
-    KafkaEx.create_worker(:stream, uris: uris())
+      KafkaEx.create_worker(
+        worker_name,
+        consumer_group: consumer_group,
+        uris: Application.get_env(:kafka_ex, :brokers)
+      )
 
-    KafkaEx.produce(
-      %Proto.Produce.Request{
-        topic: topic_name,
+      Enum.each(1..10, fn _ ->
+        KafkaEx.produce(
+          %Proto.Produce.Request{
+            topic: topic,
+            required_acks: 1,
+            partition: 0,
+            messages: [%Proto.Produce.Message{value: "hey"}]
+          },
+          worker_name: worker_name
+        )
+      end)
+
+      KafkaEx.offset_fetch(worker_name, %KafkaEx.Protocol.OffsetFetch.Request{
+        topic: topic,
+        partition: 0
+      })
+
+      assert :sys.get_state(:offset_fetch_consumer_group).consumer_group ==
+               consumer_group
+    end
+  end
+
+  describe "offset_commit/2" do
+    test "offset_commit commits an offset and offset_fetch retrieves the committed offset" do
+      random_string = generate_random_string()
+
+      Enum.each(1..10, fn _ ->
+        KafkaEx.produce(%Proto.Produce.Request{
+          topic: random_string,
+          partition: 0,
+          required_acks: 1,
+          messages: [%Proto.Produce.Message{value: "hey"}]
+        })
+      end)
+
+      assert KafkaEx.offset_commit(
+               Config.default_worker(),
+               %Proto.OffsetCommit.Request{
+                 topic: random_string,
+                 offset: 9,
+                 partition: 0
+               }
+             ) ==
+               [
+                 %Proto.OffsetCommit.Response{
+                   partitions: [0],
+                   topic: random_string
+                 }
+               ]
+
+      assert KafkaEx.offset_fetch(
+               Config.default_worker(),
+               %Proto.OffsetFetch.Request{topic: random_string, partition: 0}
+             ) ==
+               [
+                 %Proto.OffsetFetch.Response{
+                   partitions: [
+                     %{
+                       metadata: "",
+                       error_code: :no_error,
+                       offset: 9,
+                       partition: 0
+                     }
+                   ],
+                   topic: random_string
+                 }
+               ]
+    end
+  end
+
+  describe "stream/3" do
+    test "stream auto_commits offset by default" do
+      random_string = generate_random_string()
+
+      KafkaEx.create_worker(
+        :stream_auto_commit,
+        uris: uris(),
+        consumer_group: "kafka_ex"
+      )
+
+      KafkaEx.produce(%Proto.Produce.Request{
+        topic: random_string,
         partition: 0,
         required_acks: 1,
         messages: [
-          %Proto.Produce.Message{value: "message 2"},
-          %Proto.Produce.Message{value: "message 3"},
-          %Proto.Produce.Message{value: "message 4"},
-          %Proto.Produce.Message{value: "message 5"}
+          %Proto.Produce.Message{value: "hey"},
+          %Proto.Produce.Message{value: "hi"}
         ]
-      },
-      worker_name: :stream
-    )
+      })
 
-    stream =
-      KafkaEx.stream(
-        topic_name,
-        0,
-        worker_name: :stream,
-        offset: 0,
-        auto_commit: true,
+      stream =
+        KafkaEx.stream(
+          random_string,
+          0,
+          worker_name: :stream_auto_commit,
+          offset: 0
+        )
+
+      log = TestHelper.wait_for_any(fn -> Enum.take(stream, 2) end)
+
+      refute Enum.empty?(log)
+
+      [offset_fetch_response | _] =
+        KafkaEx.offset_fetch(:stream_auto_commit, %Proto.OffsetFetch.Request{
+          topic: random_string,
+          partition: 0
+        })
+
+      error_code =
+        offset_fetch_response.partitions |> hd |> Map.get(:error_code)
+
+      offset = offset_fetch_response.partitions |> hd |> Map.get(:offset)
+
+      assert error_code == :no_error
+      refute offset == 0
+    end
+
+    test "stream starts consuming from the next offset" do
+      random_string = generate_random_string()
+      consumer_group = "kafka_ex"
+      worker_name = :stream_last_committed_offset
+
+      KafkaEx.create_worker(
+        worker_name,
+        uris: uris(),
         consumer_group: consumer_group
       )
 
-    [m1, m2] = Enum.take(stream, 2)
-    assert "message 2" == m1.value
-    assert "message 3" == m2.value
+      Enum.each(1..10, fn _ ->
+        KafkaEx.produce(
+          %Proto.Produce.Request{
+            topic: random_string,
+            partition: 0,
+            required_acks: 1,
+            messages: [%Proto.Produce.Message{value: "hey"}]
+          },
+          worker_name: worker_name
+        )
+      end)
 
-    offset =
-      TestHelper.latest_consumer_offset_number(
-        topic_name,
-        0,
-        consumer_group,
-        :stream
-      )
-
-    assert offset == m2.offset
-  end
-
-  test "stream auto_commit doesn't exceed the end of the log" do
-    topic_name = generate_random_string()
-    consumer_group = "stream_test"
-
-    KafkaEx.create_worker(:stream, uris: uris())
-
-    KafkaEx.produce(
-      %Proto.Produce.Request{
-        topic: topic_name,
+      KafkaEx.offset_commit(worker_name, %Proto.OffsetCommit.Request{
+        topic: random_string,
         partition: 0,
-        required_acks: 1,
-        messages: [
-          %Proto.Produce.Message{value: "message 2"},
-          %Proto.Produce.Message{value: "message 3"},
-          %Proto.Produce.Message{value: "message 4"},
-          %Proto.Produce.Message{value: "message 5"}
-        ]
-      },
-      worker_name: :stream
-    )
+        offset: 3
+      })
 
-    stream =
-      KafkaEx.stream(
-        topic_name,
-        0,
-        worker_name: :stream,
-        offset: 0,
-        no_wait_at_logend: true,
-        auto_commit: true,
-        consumer_group: consumer_group
+      # make sure the offset commit is actually committed before we
+      # start streaming again
+      :ok =
+        TestHelper.wait_for(fn ->
+          3 ==
+            TestHelper.latest_consumer_offset_number(
+              random_string,
+              0,
+              consumer_group,
+              worker_name
+            )
+        end)
+
+      stream = KafkaEx.stream(random_string, 0, worker_name: worker_name)
+      log = TestHelper.wait_for_any(fn -> Enum.take(stream, 2) end)
+
+      refute Enum.empty?(log)
+      first_message = log |> hd
+      assert first_message.offset == 4
+    end
+
+    test "stream auto_commit deals with small batches correctly" do
+      topic_name = generate_random_string()
+      consumer_group = "stream_test"
+
+      KafkaEx.create_worker(:stream, uris: uris())
+
+      KafkaEx.produce(
+        %Proto.Produce.Request{
+          topic: topic_name,
+          partition: 0,
+          required_acks: 1,
+          messages: [
+            %Proto.Produce.Message{value: "message 2"},
+            %Proto.Produce.Message{value: "message 3"},
+            %Proto.Produce.Message{value: "message 4"},
+            %Proto.Produce.Message{value: "message 5"}
+          ]
+        },
+        worker_name: :stream
       )
 
-    [m1, m2, m3, m4] = Enum.take(stream, 10)
-    assert "message 2" == m1.value
-    assert "message 3" == m2.value
-    assert "message 4" == m3.value
-    assert "message 5" == m4.value
+      stream =
+        KafkaEx.stream(
+          topic_name,
+          0,
+          worker_name: :stream,
+          offset: 0,
+          auto_commit: true,
+          consumer_group: consumer_group
+        )
 
-    offset =
-      TestHelper.latest_consumer_offset_number(
-        topic_name,
-        0,
-        consumer_group,
-        :stream
+      [m1, m2] = Enum.take(stream, 2)
+      assert "message 2" == m1.value
+      assert "message 3" == m2.value
+
+      offset =
+        TestHelper.latest_consumer_offset_number(
+          topic_name,
+          0,
+          consumer_group,
+          :stream
+        )
+
+      assert offset == m2.offset
+    end
+
+    test "stream auto_commit doesn't exceed the end of the log" do
+      topic_name = generate_random_string()
+      consumer_group = "stream_test"
+
+      KafkaEx.create_worker(:stream, uris: uris())
+
+      KafkaEx.produce(
+        %Proto.Produce.Request{
+          topic: topic_name,
+          partition: 0,
+          required_acks: 1,
+          messages: [
+            %Proto.Produce.Message{value: "message 2"},
+            %Proto.Produce.Message{value: "message 3"},
+            %Proto.Produce.Message{value: "message 4"},
+            %Proto.Produce.Message{value: "message 5"}
+          ]
+        },
+        worker_name: :stream
       )
 
-    assert offset == m4.offset
+      stream =
+        KafkaEx.stream(
+          topic_name,
+          0,
+          worker_name: :stream,
+          offset: 0,
+          no_wait_at_logend: true,
+          auto_commit: true,
+          consumer_group: consumer_group
+        )
 
-    other_consumer_group = "another_consumer_group"
+      [m1, m2, m3, m4] = Enum.take(stream, 10)
+      assert "message 2" == m1.value
+      assert "message 3" == m2.value
+      assert "message 4" == m3.value
+      assert "message 5" == m4.value
 
-    map_stream =
-      KafkaEx.stream(
-        topic_name,
-        0,
-        worker_name: :stream,
-        no_wait_at_logend: true,
-        auto_commit: true,
-        offset: 0,
-        consumer_group: other_consumer_group
+      offset =
+        TestHelper.latest_consumer_offset_number(
+          topic_name,
+          0,
+          consumer_group,
+          :stream
+        )
+
+      assert offset == m4.offset
+
+      other_consumer_group = "another_consumer_group"
+
+      map_stream =
+        KafkaEx.stream(
+          topic_name,
+          0,
+          worker_name: :stream,
+          no_wait_at_logend: true,
+          auto_commit: true,
+          offset: 0,
+          consumer_group: other_consumer_group
+        )
+
+      assert ["message 2", "message 3", "message 4", "message 5"] =
+               Enum.map(map_stream, fn m -> m.value end)
+
+      offset =
+        TestHelper.latest_consumer_offset_number(
+          topic_name,
+          0,
+          other_consumer_group,
+          :stream
+        )
+
+      # should have the same offset as the first stream
+      assert offset == m4.offset
+    end
+
+    test "streams with a consumer group begin at the last committed offset" do
+      topic_name = generate_random_string()
+      consumer_group = "stream_test"
+
+      KafkaEx.create_worker(:stream, uris: uris())
+
+      messages_in =
+        Enum.map(
+          1..10,
+          fn ix -> %Proto.Produce.Message{value: "Msg #{ix}"} end
+        )
+
+      KafkaEx.produce(
+        %Proto.Produce.Request{
+          topic: topic_name,
+          partition: 0,
+          required_acks: 1,
+          messages: messages_in
+        },
+        worker_name: :stream
       )
 
-    assert ["message 2", "message 3", "message 4", "message 5"] =
-             Enum.map(map_stream, fn m -> m.value end)
+      stream1 =
+        KafkaEx.stream(
+          topic_name,
+          0,
+          worker_name: :stream,
+          no_wait_at_logend: true,
+          auto_commit: true,
+          offset: 0,
+          consumer_group: consumer_group
+        )
 
-    offset =
-      TestHelper.latest_consumer_offset_number(
-        topic_name,
-        0,
-        other_consumer_group,
-        :stream
-      )
+      assert ["Msg 1", "Msg 2"] ==
+               stream1
+               |> Enum.take(2)
+               |> Enum.map(fn msg -> msg.value end)
 
-    # should have the same offset as the first stream
-    assert offset == m4.offset
-  end
+      stream2 =
+        KafkaEx.stream(
+          topic_name,
+          0,
+          worker_name: :stream,
+          no_wait_at_logend: true,
+          auto_commit: true,
+          consumer_group: consumer_group
+        )
 
-  test "streams with a consumer group begin at the last committed offset" do
-    topic_name = generate_random_string()
-    consumer_group = "stream_test"
+      message_values =
+        stream2
+        |> Enum.take(2)
+        |> Enum.map(fn msg -> msg.value end)
 
-    KafkaEx.create_worker(:stream, uris: uris())
-
-    messages_in =
-      Enum.map(
-        1..10,
-        fn ix -> %Proto.Produce.Message{value: "Msg #{ix}"} end
-      )
-
-    KafkaEx.produce(
-      %Proto.Produce.Request{
-        topic: topic_name,
-        partition: 0,
-        required_acks: 1,
-        messages: messages_in
-      },
-      worker_name: :stream
-    )
-
-    stream1 =
-      KafkaEx.stream(
-        topic_name,
-        0,
-        worker_name: :stream,
-        no_wait_at_logend: true,
-        auto_commit: true,
-        offset: 0,
-        consumer_group: consumer_group
-      )
-
-    assert ["Msg 1", "Msg 2"] ==
-             stream1
-             |> Enum.take(2)
-             |> Enum.map(fn msg -> msg.value end)
-
-    stream2 =
-      KafkaEx.stream(
-        topic_name,
-        0,
-        worker_name: :stream,
-        no_wait_at_logend: true,
-        auto_commit: true,
-        consumer_group: consumer_group
-      )
-
-    message_values =
-      stream2
-      |> Enum.take(2)
-      |> Enum.map(fn msg -> msg.value end)
-
-    assert ["Msg 3", "Msg 4"] == message_values
+      assert ["Msg 3", "Msg 4"] == message_values
+    end
   end
 end


### PR DESCRIPTION
This PR adds an implementation for Kafka's describe_groups API.
Given a consumer group name, we issue a Kayrock.DescribeGroups to the
broker controlling that group and return the response to the caller. In
case of errors, we retry the request up to 3 times by default.
